### PR TITLE
Fix readme

### DIFF
--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -155,7 +155,7 @@ The `./backend/app` directory is mounted as a "host volume" inside the docker co
 You can rerun the test on live code:
 
 ```Bash
-docker-compose exec backend /app/tests-start.sh
+docker-compose exec backend bash /app/tests-start.sh
 ```
 
 #### Test running stack
@@ -163,7 +163,7 @@ docker-compose exec backend /app/tests-start.sh
 If your stack is already up and you just want to run the tests, you can use:
 
 ```bash
-docker-compose exec backend /app/tests-start.sh
+docker-compose exec backend bash /app/tests-start.sh
 ```
 
 That `/app/tests-start.sh` script just calls `pytest` after making sure that the rest of the stack is running. If you need to pass extra arguments to `pytest`, you can pass them to that command and they will be forwarded.


### PR DESCRIPTION
docker-compose exec commands in README fail without shell call.